### PR TITLE
Fix yaml plugin loading on Python 3.9

### DIFF
--- a/pptop/core.py
+++ b/pptop/core.py
@@ -1318,7 +1318,7 @@ def start():
         if not os.path.isdir(_d.pptop_dir + '/lib'):
             os.mkdir(_d.pptop_dir + '/lib')
     with open(config_file) as fh:
-        config.update(yaml.load(fh.read()))
+        config.update(yaml.safe_load(fh.read()))
 
     console = config.get('console')
     if console is None: console = {}


### PR DESCRIPTION
You get an error trying to run this with Python 3.9 and latest pip
install:
```
$ pptop <PID>                                                                                                                                                                                                               
load() missing 1 required positional argument: 'Loader' 
```

Since the PyYAML library [API changed](https://github.com/yaml/pyyaml/issues/576),
we need to use `safe_load` (which should be the default anyways).